### PR TITLE
fix: allow `:build_type` to be specified in any order

### DIFF
--- a/lib/cocoapods-user-defined-build-types/private_api_hooks.rb
+++ b/lib/cocoapods-user-defined-build-types/private_api_hooks.rb
@@ -27,7 +27,7 @@ module Pod
 
         if options.is_a?(Hash)
           options.each do |k,v|
-            next if not options.key?(Pod::UserOption.keyword)
+            next if k != Pod::UserOption.keyword
              
             user_build_type = options.delete(k)
             if Pod::UserOption.keyword_mapping.key?(user_build_type)


### PR DESCRIPTION
Fixes #4 

First off -- thank you for this plugin! What a game changer! Has been working out great.

This PR fixes a small logic bug that required `:build_type` to always be the first option.

While iterating through the `|k,v|` entries of `options`, the intent was to only operate on `:build_type`.
Previously, the check was `next if not options.key?(Pod::UserOption.keyword)` ("does :build_type exist?")
This would be `true` even if `k` was not `:build_type`, causing the wrong key to be operated on (unless `build_type` was first)

This PR changes the check to `next if k != Pod::UserOption.keyword`, and I have verified that this results in the intended behavior.
However, I'm not totally sure how to implement tests of this behavior -- I don't work in ruby very often. Happy to help with that if you have any guidance, though!

Thank you for reviewing!