### PR TITLE
Bump maximum CocoaPods to 1.10.0-rc.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # cocoapods-user-defined-build-types
-![Latest Version](https://img.shields.io/badge/Latest_supported_CocoaPods-1.9.1-gray.svg)
+![Latest Version](https://img.shields.io/badge/Latest_supported_CocoaPods-1.10.0.rc.1-gray.svg)
 
 Allow CocoaPods to mix dynamic/static libaries/frameworks.
 

--- a/lib/cocoapods-user-defined-build-types/main.rb
+++ b/lib/cocoapods-user-defined-build-types/main.rb
@@ -19,7 +19,7 @@ end
 
 module CocoapodsUserDefinedBuildTypes
   PLUGIN_NAME = 'cocoapods-user-defined-build-types'
-  LATEST_SUPPORTED_COCOAPODS_VERSION = '1.9.1'
+  LATEST_SUPPORTED_COCOAPODS_VERSION = '1.10.0.rc.1'
   
   @@plugin_enabled = false
   @@verbose_logging = false


### PR DESCRIPTION
Hi again @joncardasis!

I've been using this plugin without issue on the latest CocoaPods `1.9.3` as well as the recent prerelease `1.10.0-rc.1`.

Initially, I downgraded my installed version due to the currently-listed limitation, but everything seems fine on the latest versions too.

Didn't want to come across as a "spamtoberfest" docs-only PR, so I made sure to hit a real bug first with #6 :stuck_out_tongue_closed_eyes: Keeping this as a draft for now too, pending discussion.

It could make sense to ignore the prerelease version, and since this is an ongoing maintenance responsibility, perhaps we could come up with a way to use Github actions to test some stub `Podfile`s on different CocoaPods versions. Let me know what you think.

And again, thanks so much for this plugin!